### PR TITLE
Add jpeg cmyk ycck support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.sanselan</groupId>
+      <artifactId>sanselan</artifactId>
+      <version>0.97-incubator</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/src/main/java/com/koadweb/javafpdf/FPDF.java
+++ b/src/main/java/com/koadweb/javafpdf/FPDF.java
@@ -22,11 +22,8 @@
 package com.koadweb.javafpdf;
 
 import com.koadweb.javafpdf.util.Compressor;
-import java.awt.Graphics2D;
-import java.awt.Toolkit;
 import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
-import java.awt.image.Raster;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -39,17 +36,11 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.ImageInputStream;
-import javax.swing.ImageIcon;
 import org.apache.sanselan.ImageReadException;
 
 /**

--- a/src/main/java/com/koadweb/javafpdf/FPDF.java
+++ b/src/main/java/com/koadweb/javafpdf/FPDF.java
@@ -22,8 +22,11 @@
 package com.koadweb.javafpdf;
 
 import com.koadweb.javafpdf.util.Compressor;
+import java.awt.Graphics2D;
+import java.awt.Toolkit;
 import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
+import java.awt.image.Raster;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -36,11 +39,18 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import javax.swing.ImageIcon;
+import org.apache.sanselan.ImageReadException;
 
 /**
  * Faithful Java port of <a href="http://www.fpdf.org">FPDF for PHP</a>.
@@ -591,11 +601,13 @@ public abstract class FPDF {
 			}
 		}
 	}
-
+        
 	protected Map<String, Object> _parsejpg(String fileName, byte[] data) {
 		BufferedImage img = null;
 		try {
-			img = ImageIO.read(new ByteArrayInputStream(data));
+			// Image quality isn't the best this way but it fully supports CMYK and YCCK
+                        JpegReader jpegReader = new JpegReader();
+                        img = jpegReader.readImage(data);
 			
 			Map<String, Object> image = new HashMap<>();
 			image.put("w", Integer.valueOf(img.getWidth())); 
@@ -619,7 +631,7 @@ public abstract class FPDF {
 			ImageIO.write(img, "jpg", boas);
 			image.put("data", boas.toByteArray()); 
 			return image;
-		} catch (IOException e) {
+		} catch (IOException | ImageReadException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/com/koadweb/javafpdf/FPDF.java
+++ b/src/main/java/com/koadweb/javafpdf/FPDF.java
@@ -601,12 +601,19 @@ public abstract class FPDF {
                         img = jpegReader.readImage(data);
 			
 			String colspace;
-                        // Output from jpegReader should always be RGB but still throw just in case it somehow isn't
-			if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_RGB) {
-				colspace = "DeviceRGB";
-			} else {
-				throw new IllegalArgumentException("Ungültiges Farbmodell " + img.getColorModel().getColorSpace().getType());
-			}
+                        // In some cases ColorSpaces get converted by jpegReader but not always
+                        // 9 - TYPE_CMYK
+                        // 5 - TYPE_RGB
+                        // 6 - TYPE_GRAY
+			if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_CMYK) {
+ 				colspace = "DeviceCMYK";
+ 			} else if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_RGB) {
+ 				colspace = "DeviceRGB";
+ 			} else if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_GRAY) {
+ 				colspace = "DeviceGray";
+ 			} else {
+ 				throw new IllegalArgumentException("Ungültiges Farbmodell " + img.getColorModel().getColorSpace().getType());
+ 			}
                         // 
                         ByteArrayOutputStream boas = new ByteArrayOutputStream();
 			ImageIO.write(img, "jpg", boas);

--- a/src/main/java/com/koadweb/javafpdf/FPDF.java
+++ b/src/main/java/com/koadweb/javafpdf/FPDF.java
@@ -600,26 +600,24 @@ public abstract class FPDF {
                         JpegReader jpegReader = new JpegReader();
                         img = jpegReader.readImage(data);
 			
-			Map<String, Object> image = new HashMap<>();
-			image.put("w", Integer.valueOf(img.getWidth())); 
-			image.put("h", Integer.valueOf(img.getHeight())); 
 			String colspace;
-			if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_CMYK) {
-				colspace = "DeviceCMYK";
-			} else if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_RGB) {
+                        // Output from jpegReader should always be RGB but still throw just in case it somehow isn't
+			if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_RGB) {
 				colspace = "DeviceRGB";
-			} else if (img.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_GRAY) {
-				colspace = "DeviceGray";
 			} else {
 				throw new IllegalArgumentException("Ungültiges Farbmodell " + img.getColorModel().getColorSpace().getType());
 			}
+                        // 
+                        ByteArrayOutputStream boas = new ByteArrayOutputStream();
+			ImageIO.write(img, "jpg", boas);
+                        // Load image map with img metadata / raw image data
+                        Map<String, Object> image = new HashMap<>();
+                        image.put("w", Integer.valueOf(img.getWidth()));
+			image.put("h", Integer.valueOf(img.getHeight()));
 			image.put("cs", colspace); 
 			image.put("bpc", 8); 
 			image.put("f", "DCTDecode"); 
 			image.put("i", Integer.valueOf(this.images.size() + 1)); 
-			
-			ByteArrayOutputStream boas = new ByteArrayOutputStream();
-			ImageIO.write(img, "jpg", boas);
 			image.put("data", boas.toByteArray()); 
 			return image;
 		} catch (IOException | ImageReadException e) {

--- a/src/main/java/com/koadweb/javafpdf/JpegReader.java
+++ b/src/main/java/com/koadweb/javafpdf/JpegReader.java
@@ -1,0 +1,224 @@
+
+package com.koadweb.javafpdf;
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorConvertOp;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import javax.imageio.IIOException;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import org.apache.sanselan.ImageReadException;
+import org.apache.sanselan.Sanselan;
+import org.apache.sanselan.common.byteSources.ByteSource;
+import org.apache.sanselan.common.byteSources.ByteSourceArray;
+import org.apache.sanselan.common.byteSources.ByteSourceFile;
+import org.apache.sanselan.formats.jpeg.JpegImageParser;
+import org.apache.sanselan.formats.jpeg.segments.UnknownSegment;
+
+/**
+ * All thanks go to Codo @ Stack Overflow for this gem
+ * http://stackoverflow.com/questions/3123574/how-to-convert-from-cmyk-to-rgb-in-java-correctly
+ * Can't believe this isn't built in to the ImageIO class ...
+ */
+public class JpegReader {
+
+    public static final int COLOR_TYPE_RGB = 1;
+    public static final int COLOR_TYPE_CMYK = 2;
+    public static final int COLOR_TYPE_YCCK = 3;
+
+    private int colorType = COLOR_TYPE_RGB;
+    private boolean hasAdobeMarker = false;
+
+    public BufferedImage readImage(byte[] bytes) throws IOException, ImageReadException {
+        colorType = COLOR_TYPE_RGB;
+        hasAdobeMarker = false;
+        ImageInputStream stream = ImageIO.createImageInputStream(new ByteArrayInputStream(bytes));
+        Iterator<ImageReader> iter = ImageIO.getImageReaders(stream);
+        while (iter.hasNext()) {
+            ImageReader reader = iter.next();
+            reader.setInput(stream);
+
+            BufferedImage image;
+            ICC_Profile profile = null;
+            try {
+                image = reader.read(0);
+            } catch (IIOException e) {
+                colorType = COLOR_TYPE_CMYK;
+                checkAdobeMarker(bytes);
+                profile = Sanselan.getICCProfile(bytes);
+                WritableRaster raster = (WritableRaster) reader.readRaster(0, null);
+                if (colorType == COLOR_TYPE_YCCK)
+                    convertYcckToCmyk(raster);
+                if (hasAdobeMarker)
+                    convertInvertedColors(raster);
+                image = convertCmykToRgb(raster, profile);
+            }
+
+            return image;
+        }
+
+        return null;
+    }
+    
+    public BufferedImage readImage(File file) throws IOException, ImageReadException {
+        colorType = COLOR_TYPE_RGB;
+        hasAdobeMarker = false;
+        ImageInputStream stream = ImageIO.createImageInputStream(file);
+        Iterator<ImageReader> iter = ImageIO.getImageReaders(stream);
+        while (iter.hasNext()) {
+            ImageReader reader = iter.next();
+            reader.setInput(stream);
+
+            BufferedImage image;
+            ICC_Profile profile = null;
+            try {
+                image = reader.read(0);
+            } catch (IIOException e) {
+                colorType = COLOR_TYPE_CMYK;
+                checkAdobeMarker(file);
+                profile = Sanselan.getICCProfile(file);
+                WritableRaster raster = (WritableRaster) reader.readRaster(0, null);
+                if (colorType == COLOR_TYPE_YCCK)
+                    convertYcckToCmyk(raster);
+                if (hasAdobeMarker)
+                    convertInvertedColors(raster);
+                image = convertCmykToRgb(raster, profile);
+            }
+
+            return image;
+        }
+
+        return null;
+    }
+    
+    /**
+     * Check Adobe markers in File
+     * @param file
+     * @throws IOException
+     * @throws ImageReadException 
+     */
+    public void checkAdobeMarker(File file) throws IOException, ImageReadException {
+        JpegImageParser parser = new JpegImageParser();
+        ByteSource byteSource = new ByteSourceFile(file);
+        @SuppressWarnings("rawtypes")
+        ArrayList segments = parser.readSegments(byteSource, new int[] { 0xffee }, true);
+        if (segments != null && segments.size() >= 1) {
+            UnknownSegment app14Segment = (UnknownSegment) segments.get(0);
+            byte[] data = app14Segment.bytes;
+            if (data.length >= 12 && data[0] == 'A' && data[1] == 'd' && data[2] == 'o' && data[3] == 'b' && data[4] == 'e')
+            {
+                hasAdobeMarker = true;
+                int transform = app14Segment.bytes[11] & 0xff;
+                if (transform == 2)
+                    colorType = COLOR_TYPE_YCCK;
+            }
+        }
+    }
+    
+    /**
+     * Check Adobe markers in byte array
+     * @param bytes
+     * @throws IOException
+     * @throws ImageReadException 
+     */
+    public void checkAdobeMarker(byte[] bytes) throws IOException, ImageReadException {
+        JpegImageParser parser = new JpegImageParser();
+        ByteSource byteSource = new ByteSourceArray(bytes);
+        @SuppressWarnings("rawtypes")
+        ArrayList segments = parser.readSegments(byteSource, new int[] { 0xffee }, true);
+        if (segments != null && segments.size() >= 1) {
+            UnknownSegment app14Segment = (UnknownSegment) segments.get(0);
+            byte[] data = app14Segment.bytes;
+            if (data.length >= 12 && data[0] == 'A' && data[1] == 'd' && data[2] == 'o' && data[3] == 'b' && data[4] == 'e')
+            {
+                hasAdobeMarker = true;
+                int transform = app14Segment.bytes[11] & 0xff;
+                if (transform == 2)
+                    colorType = COLOR_TYPE_YCCK;
+            }
+        }
+    }
+    
+    public static void convertYcckToCmyk(WritableRaster raster) {
+        int height = raster.getHeight();
+        int width = raster.getWidth();
+        int stride = width * 4;
+        int[] pixelRow = new int[stride];
+        for (int h = 0; h < height; h++) {
+            raster.getPixels(0, h, width, 1, pixelRow);
+
+            for (int x = 0; x < stride; x += 4) {
+                int y = pixelRow[x];
+                int cb = pixelRow[x + 1];
+                int cr = pixelRow[x + 2];
+
+                int c = (int) (y + 1.402 * cr - 178.956);
+                int m = (int) (y - 0.34414 * cb - 0.71414 * cr + 135.95984);
+                y = (int) (y + 1.772 * cb - 226.316);
+
+                if (c < 0) c = 0; else if (c > 255) c = 255;
+                if (m < 0) m = 0; else if (m > 255) m = 255;
+                if (y < 0) y = 0; else if (y > 255) y = 255;
+
+                pixelRow[x] = 255 - c;
+                pixelRow[x + 1] = 255 - m;
+                pixelRow[x + 2] = 255 - y;
+            }
+
+            raster.setPixels(0, h, width, 1, pixelRow);
+        }
+    }
+
+    public static void convertInvertedColors(WritableRaster raster) {
+        int height = raster.getHeight();
+        int width = raster.getWidth();
+        int stride = width * 4;
+        int[] pixelRow = new int[stride];
+        for (int h = 0; h < height; h++) {
+            raster.getPixels(0, h, width, 1, pixelRow);
+            for (int x = 0; x < stride; x++)
+                pixelRow[x] = 255 - pixelRow[x];
+            raster.setPixels(0, h, width, 1, pixelRow);
+        }
+    }
+
+    public static BufferedImage convertCmykToRgb(Raster cmykRaster, ICC_Profile cmykProfile) throws IOException {
+        if (cmykProfile == null)
+            cmykProfile = ICC_Profile.getInstance(JpegReader.class.getResourceAsStream("/ISOcoated_v2_300_eci.icc"));
+
+        if (cmykProfile.getProfileClass() != ICC_Profile.CLASS_DISPLAY) {
+            byte[] profileData = cmykProfile.getData();
+
+            if (profileData[ICC_Profile.icHdrRenderingIntent] == ICC_Profile.icPerceptual) {
+                intToBigEndian(ICC_Profile.icSigDisplayClass, profileData, ICC_Profile.icHdrDeviceClass); // Header is first
+
+                cmykProfile = ICC_Profile.getInstance(profileData);
+            }
+        }
+
+        ICC_ColorSpace cmykCS = new ICC_ColorSpace(cmykProfile);
+        BufferedImage rgbImage = new BufferedImage(cmykRaster.getWidth(), cmykRaster.getHeight(), BufferedImage.TYPE_INT_RGB);
+        WritableRaster rgbRaster = rgbImage.getRaster();
+        ColorSpace rgbCS = rgbImage.getColorModel().getColorSpace();
+        ColorConvertOp cmykToRgb = new ColorConvertOp(cmykCS, rgbCS, null);
+        cmykToRgb.filter(cmykRaster, rgbRaster);
+        return rgbImage;
+    }
+    
+    static void intToBigEndian(int value, byte[] array, int index) {
+      array[index]   = (byte) (value >> 24);
+      array[index+1] = (byte) (value >> 16);
+      array[index+2] = (byte) (value >>  8);
+      array[index+3] = (byte) (value);
+    }
+}


### PR DESCRIPTION
- Bring Apache Sanselan library in for additional JPEG image processing support
- Implemented JpegReader class to handle CMYK and YCCK color models
- Added byte array support to JpegReader for better processing efficiency vs temp files
